### PR TITLE
test: tweak test:lint command + add test:lint:fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "scripts": {
     "test": "npm run test:lint && npm run test:unit",
-    "test:lint": "standard --fix",
+    "test:lint": "standard",
+    "test:lint:fix": "standard --fix",
     "test:unit": "node test/parallel/* && node test/message && node test/node-core-test.js"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR updates the `lint:test` command, removing the `--fix` flag from it, and adds a `test:lint:fix` command, which has the same functionality as the old `lint:test`.

Others might have differing opinions, but in my experience I really don't usually want my default test command (that's used by other commands and is often something people run immediately when they clone/are trying to make a PR) to be making code changes.

Figured I'd throw up a quick PR for this. If including `--fix` is a desired approach, feel free to close this PR.