### PR TITLE
fix(test): ensure all tests are run and fix failing ones

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -359,3 +359,9 @@ E('ERR_TEST_FAILURE', function (error, failureType) {
   this.cause = error
   return msg
 }, Error)
+E('ERR_INVALID_ARG_TYPE',
+  (name, expected, actual) => `Expected ${name} to be ${expected}, got type ${typeof actual}`,
+  TypeError)
+E('ERR_OUT_OF_RANGE',
+  (name, expected, actual) => `Expected ${name} to be ${expected}, got ${actual}`,
+  RangeError)

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -22,6 +22,7 @@ const { once } = require('events')
 const { AbortController } = require('#internal/abort_controller')
 const {
   codes: {
+    ERR_INVALID_ARG_TYPE,
     ERR_TEST_FAILURE
   },
   kIsNodeError,
@@ -167,7 +168,7 @@ class Test extends AsyncResource {
         break
 
       default:
-        if (concurrency != null) throw new TypeError(`Expected options.concurrency to be a number or boolean, got ${concurrency}`)
+        if (concurrency != null) throw new ERR_INVALID_ARG_TYPE('options.concurrency', 'a number or boolean', concurrency)
     }
 
     if (timeout != null && timeout !== Infinity) {

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -1,16 +1,25 @@
 // https://github.com/nodejs/node/blob/60da0a1b364efdd84870269d23b39faa12fb46d8/lib/internal/validators.js
+const {
+  ERR_INVALID_ARG_TYPE,
+  ERR_OUT_OF_RANGE
+} = require('#internal/errors').codes
+
 function isUint32 (value) {
   return value === (value >>> 0)
 }
 
 function validateNumber (value, name, min = undefined, max) {
-  if (typeof value !== 'number') { throw new TypeError(`Expected ${name} to be a number, got ${value}`) }
+  if (typeof value !== 'number') {
+    throw new ERR_INVALID_ARG_TYPE(name, 'a number', value)
+  }
 
   if ((min != null && value < min) || (max != null && value > max) ||
       ((min != null || max != null) && Number.isNaN(value))) {
-    throw new RangeError(`Expected ${name} to be ${
-      `${min != null ? `>= ${min}` : ''}${min != null && max != null ? ' && ' : ''}${max != null ? `<= ${max}` : ''}`
-    }, got ${value}`)
+    throw new ERR_OUT_OF_RANGE(
+      name,
+      `${min != null ? `>= ${min}` : ''}${min != null && max != null ? ' && ' : ''}${max != null ? `<= ${max}` : ''}`,
+      value
+    )
   }
 }
 
@@ -19,22 +28,22 @@ const validateAbortSignal = (signal, name) => {
       (signal === null ||
        typeof signal !== 'object' ||
        !('aborted' in signal))) {
-    throw new TypeError(`Expected ${name} to be an AbortSignal, got ${signal}`)
+    throw new ERR_INVALID_ARG_TYPE(name, 'an AbortSignal', signal)
   }
 }
 
 const validateUint32 = (value, name, positive) => {
   if (typeof value !== 'number') {
-    throw new TypeError(`Expected ${name} to be a number, got ${value}`)
+    throw new ERR_INVALID_ARG_TYPE(name, 'a number', value)
   }
   if (!Number.isInteger(value)) {
-    throw new RangeError(`Expected ${name} to be an integer, got ${value}`)
+    throw new ERR_OUT_OF_RANGE(name, 'an integer', value)
   }
   const min = positive ? 1 : 0
   // 2 ** 32 === 4294967296
   const max = 4_294_967_295
   if (value < min || value > max) {
-    throw new RangeError(`Expected ${name} to be ${`>= ${min} && <= ${max}`}, got ${value}`)
+    throw new ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "npm run test:lint && npm run test:unit",
     "test:lint": "standard",
     "test:lint:fix": "standard --fix",
-    "test:unit": "node test/parallel/* && node test/message && node test/node-core-test.js"
+    "test:unit": "node test/parallel.mjs && node test/message.js && node test/node-core-test.js"
   },
   "devDependencies": {
     "standard": "^17.0.0"

--- a/test/parallel.mjs
+++ b/test/parallel.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+import { once } from 'node:events'
+import { spawn } from 'node:child_process'
+import fs from 'node:fs/promises'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const PARALLEL_DIR = new URL('./parallel/', import.meta.url)
+const dir = await fs.opendir(PARALLEL_DIR)
+
+for await (const { name } of dir) {
+  if (!name.endsWith('.js')) continue
+  const cp = spawn(
+    process.execPath,
+    [fileURLToPath(new URL(name, PARALLEL_DIR))],
+    { stdio: 'inherit' }
+  )
+  const [code] = await once(cp, 'exit')
+  if (code) process.exit(code)
+}

--- a/test/parallel/test-runner-misc.js
+++ b/test/parallel/test-runner-misc.js
@@ -4,10 +4,10 @@
 const common = require('../common')
 const assert = require('assert')
 const { spawnSync } = require('child_process')
-const { setTimeout } = require('timers/promises')
+const { setTimeout } = require('#timers/promises')
 
 if (process.argv[2] === 'child') {
-  const test = require('node:test')
+  const test = require('#node:test')
 
   if (process.argv[3] === 'abortSignal') {
     assert.throws(() => test({ signal: {} }), {

--- a/test/parallel/test-runner-option-validation.js
+++ b/test/parallel/test-runner-option-validation.js
@@ -3,7 +3,7 @@
 'use strict'
 require('../common')
 const assert = require('assert')
-const test = require('node:test');
+const test = require('#node:test');
 
 // eslint-disable-next-line symbol-description
 [Symbol(), {}, [], () => {}, 1n, true, '1'].forEach((timeout) => {


### PR DESCRIPTION
I'm not sure what was `node test/parallel/*` suppose to do, but clearly it wasn't reporting test failures. Instead I created a small script that execute all the files one by one (which makes "parallel" a very bad name for it, but that's also much easier to setup so here you go).