### PR TITLE
fix: make test runner work even if there is no `AbortSignal` support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,6 @@ jobs:
     strategy:
       matrix:
         node: ['14', '16', '18']
-        include:
-          - node: '14'
-            env: --experimental-abortcontroller --no-warnings
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -19,5 +16,7 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: npm ci
       - run: npm test
+      - name: Run test with experimental flag
+        run: npm test
         env:
-          NODE_OPTIONS: ${{ matrix.env }}
+          NODE_OPTIONS: --experimental-abortcontroller --no-warnings

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Minimal dependencies, with full test suite.
 Differences from the core implementation:
 
 - Doesn't hide its own stack frames.
+- Some features require the use of `--experimental-abortcontroller` CLI flag to
+  work on Node.js v14.x. It's recommended to pass
+  `NODE_OPTIONS='--experimental-abortcontroller --no-warnings'` in your env if
+  you are testing on v14.x.
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ internally.
   - `only` {boolean} If truthy, and the test context is configured to run
     `only` tests, then this test will be run. Otherwise, the test is skipped.
     **Default:** `false`.
-  - `signal` {AbortSignal} Allows aborting an in-progress test (except on Node.js v14.x).
+  - `signal` {AbortSignal} Allows aborting an in-progress test.
   - `skip` {boolean|string} If truthy, the test is skipped. If a string is
     provided, that string is displayed in the test results as the reason for
     skipping the test. **Default:** `false`.
@@ -451,7 +451,7 @@ same as [`it([name], { todo: true }[, fn])`][it options].
   function.
 * `options` {Object} Configuration options for the hook. The following
   properties are supported:
-  * `signal` {AbortSignal} Allows aborting an in-progress hook (except on Node.js v14.x).
+  * `signal` {AbortSignal} Allows aborting an in-progress hook.
   * `timeout` {number} A number of milliseconds the hook will fail after.
     If unspecified, subtests inherit this value from their parent.
     **Default:** `Infinity`.
@@ -475,7 +475,7 @@ describe('tests', async () => {
   function.
 * `options` {Object} Configuration options for the hook. The following
   properties are supported:
-  * `signal` {AbortSignal} Allows aborting an in-progress hook (except on Node.js v14.x).
+  * `signal` {AbortSignal} Allows aborting an in-progress hook.
   * `timeout` {number} A number of milliseconds the hook will fail after.
     If unspecified, subtests inherit this value from their parent.
     **Default:** `Infinity`.
@@ -499,7 +499,7 @@ describe('tests', async () => {
   function.
 * `options` {Object} Configuration options for the hook. The following
   properties are supported:
-  * `signal` {AbortSignal} Allows aborting an in-progress hook (except on Node.js v14.x).
+  * `signal` {AbortSignal} Allows aborting an in-progress hook.
   * `timeout` {number} A number of milliseconds the hook will fail after.
     If unspecified, subtests inherit this value from their parent.
     **Default:** `Infinity`.
@@ -524,7 +524,7 @@ describe('tests', async () => {
   function.
 * `options` {Object} Configuration options for the hook. The following
   properties are supported:
-  * `signal` {AbortSignal} Allows aborting an in-progress hook (except on Node.js v14.x).
+  * `signal` {AbortSignal} Allows aborting an in-progress hook.
   * `timeout` {number} A number of milliseconds the hook will fail after.
     If unspecified, subtests inherit this value from their parent.
     **Default:** `Infinity`.
@@ -555,7 +555,7 @@ exposed as part of the API.
   function.
 * `options` {Object} Configuration options for the hook. The following
   properties are supported:
-  * `signal` {AbortSignal} Allows aborting an in-progress hook (except on Node.js v14.x).
+  * `signal` {AbortSignal} Allows aborting an in-progress hook.
   * `timeout` {number} A number of milliseconds the hook will fail after.
     If unspecified, subtests inherit this value from their parent.
     **Default:** `Infinity`.
@@ -583,7 +583,7 @@ test('top level test', async (t) => {
   function.
 * `options` {Object} Configuration options for the hook. The following
   properties are supported:
-  * `signal` {AbortSignal} Allows aborting an in-progress hook (except on Node.js v14.x).
+  * `signal` {AbortSignal} Allows aborting an in-progress hook.
   * `timeout` {number} A number of milliseconds the hook will fail after.
     If unspecified, subtests inherit this value from their parent.
     **Default:** `Infinity`.
@@ -628,6 +628,11 @@ no-op.
 
 * [`AbortSignal`][] Can be used to abort test subtasks when the test has been aborted.
 
+> **Warning**
+> On Node.js v14.x, this feature won't be available unless you pass the
+> `--experimental-abortcontroller` CLI flag or added an external global polyfill
+> for `AbortController`.
+
 ```js
 test('top level test', async (t) => {
   await fetch('some/uri', { signal: t.signal });
@@ -667,7 +672,7 @@ execution of the test function. This function does not return a value.
   - `skip` {boolean|string} If truthy, the test is skipped. If a string is
     provided, that string is displayed in the test results as the reason for
     skipping the test. **Default:** `false`.
-  - `signal` {AbortSignal} Allows aborting an in-progress test (except on Node.js v14.x).
+  - `signal` {AbortSignal} Allows aborting an in-progress test.
   - `todo` {boolean|string} If truthy, the test marked as `TODO`. If a string
     is provided, that string is displayed in the test results as the reason why
     the test is `TODO`. **Default:** `false`.
@@ -696,6 +701,12 @@ The name of the suite.
 ### `context.signal`
 
 * [`AbortSignal`][] Can be used to abort test subtasks when the test has been aborted.
+
+> **Warning**
+> On Node.js v14.x, this feature won't be available unless you pass the
+> `--experimental-abortcontroller` CLI flag or added an external global polyfill
+> for `AbortController`.
+
 
 [`AbortSignal`]: https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
 [TAP]: https://testanything.org/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Minimal dependencies, with full test suite.
 Differences from the core implementation:
 
 - Doesn't hide its own stack frames.
-- Requires `--experimental-abortcontroller` CLI flag to work on Node.js v14.x.
 
 ## Docs
 
@@ -339,7 +338,7 @@ internally.
   - `only` {boolean} If truthy, and the test context is configured to run
     `only` tests, then this test will be run. Otherwise, the test is skipped.
     **Default:** `false`.
-  * `signal` {AbortSignal} Allows aborting an in-progress test.
+  - `signal` {AbortSignal} Allows aborting an in-progress test (except on Node.js v14.x).
   - `skip` {boolean|string} If truthy, the test is skipped. If a string is
     provided, that string is displayed in the test results as the reason for
     skipping the test. **Default:** `false`.
@@ -448,7 +447,7 @@ same as [`it([name], { todo: true }[, fn])`][it options].
   function.
 * `options` {Object} Configuration options for the hook. The following
   properties are supported:
-  * `signal` {AbortSignal} Allows aborting an in-progress hook.
+  * `signal` {AbortSignal} Allows aborting an in-progress hook (except on Node.js v14.x).
   * `timeout` {number} A number of milliseconds the hook will fail after.
     If unspecified, subtests inherit this value from their parent.
     **Default:** `Infinity`.
@@ -472,7 +471,7 @@ describe('tests', async () => {
   function.
 * `options` {Object} Configuration options for the hook. The following
   properties are supported:
-  * `signal` {AbortSignal} Allows aborting an in-progress hook.
+  * `signal` {AbortSignal} Allows aborting an in-progress hook (except on Node.js v14.x).
   * `timeout` {number} A number of milliseconds the hook will fail after.
     If unspecified, subtests inherit this value from their parent.
     **Default:** `Infinity`.
@@ -496,7 +495,7 @@ describe('tests', async () => {
   function.
 * `options` {Object} Configuration options for the hook. The following
   properties are supported:
-  * `signal` {AbortSignal} Allows aborting an in-progress hook.
+  * `signal` {AbortSignal} Allows aborting an in-progress hook (except on Node.js v14.x).
   * `timeout` {number} A number of milliseconds the hook will fail after.
     If unspecified, subtests inherit this value from their parent.
     **Default:** `Infinity`.
@@ -521,7 +520,7 @@ describe('tests', async () => {
   function.
 * `options` {Object} Configuration options for the hook. The following
   properties are supported:
-  * `signal` {AbortSignal} Allows aborting an in-progress hook.
+  * `signal` {AbortSignal} Allows aborting an in-progress hook (except on Node.js v14.x).
   * `timeout` {number} A number of milliseconds the hook will fail after.
     If unspecified, subtests inherit this value from their parent.
     **Default:** `Infinity`.
@@ -552,7 +551,7 @@ exposed as part of the API.
   function.
 * `options` {Object} Configuration options for the hook. The following
   properties are supported:
-  * `signal` {AbortSignal} Allows aborting an in-progress hook.
+  * `signal` {AbortSignal} Allows aborting an in-progress hook (except on Node.js v14.x).
   * `timeout` {number} A number of milliseconds the hook will fail after.
     If unspecified, subtests inherit this value from their parent.
     **Default:** `Infinity`.
@@ -580,7 +579,7 @@ test('top level test', async (t) => {
   function.
 * `options` {Object} Configuration options for the hook. The following
   properties are supported:
-  * `signal` {AbortSignal} Allows aborting an in-progress hook.
+  * `signal` {AbortSignal} Allows aborting an in-progress hook (except on Node.js v14.x).
   * `timeout` {number} A number of milliseconds the hook will fail after.
     If unspecified, subtests inherit this value from their parent.
     **Default:** `Infinity`.
@@ -664,7 +663,7 @@ execution of the test function. This function does not return a value.
   - `skip` {boolean|string} If truthy, the test is skipped. If a string is
     provided, that string is displayed in the test results as the reason for
     skipping the test. **Default:** `false`.
-  - `signal` {AbortSignal} Allows aborting an in-progress test.
+  - `signal` {AbortSignal} Allows aborting an in-progress test (except on Node.js v14.x).
   - `todo` {boolean|string} If truthy, the test marked as `TODO`. If a string
     is provided, that string is displayed in the test results as the reason why
     the test is `TODO`. **Default:** `false`.

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -1,6 +1,9 @@
 'use strict'
 
 if (typeof AbortController === 'undefined') {
+  // Node.js AbortController implementation is behind a CLI flag.
+  // This is a minimal mock to make the code work if the native
+  // implementation in not available.
   module.exports = {
     AbortController: class AbortController {
       #eventListeners = new Set()
@@ -22,7 +25,6 @@ if (typeof AbortController === 'undefined') {
   }
 } else {
   module.exports = {
-    AbortController,
-    AbortSignal
+    AbortController
   }
 }

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -1,6 +1,28 @@
 'use strict'
 
-module.exports = {
-  AbortController,
-  AbortSignal
+if (typeof AbortController === 'undefined') {
+  module.exports = {
+    AbortController: class AbortController {
+      #eventListeners = new Set()
+      signal = {
+        aborted: false,
+        addEventListener: (_, listener) => {
+          this.#eventListeners.add(listener)
+        },
+        removeEventListener: (_, listener) => {
+          this.#eventListeners.delete(listener)
+        }
+      }
+
+      abort () {
+        this.signal.aborted = true
+        this.#eventListeners.forEach(listener => listener())
+      }
+    }
+  }
+} else {
+  module.exports = {
+    AbortController,
+    AbortSignal
+  }
 }

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -102,7 +102,7 @@ function expectsError (validator, exact) {
   }, exact)
 }
 
-if (typeof AbortSignal.timeout !== 'function') {
+if (typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout !== 'function') {
   // `AbortSignal.timeout` is not available on Node.js 14.x, we need to polyfill
   // it because some tests are using it. End-users don't need to it.
 
@@ -121,7 +121,7 @@ if (typeof AbortSignal.timeout !== 'function') {
   }
 }
 
-if (process.version.startsWith('v14.') || process.version.startsWith('v16.')) {
+if (typeof AbortSignal !== 'undefined' && (process.version.startsWith('v14.') || process.version.startsWith('v16.'))) {
   // Implementation of AbortSignal and AbortController differ slightly with the
   // v18.x one, creating some difference on the TAP output which makes the tests
   // fail. We are overriding the built-ins to make the test pass, however that's

--- a/test/message.js
+++ b/test/message.js
@@ -84,6 +84,10 @@ const main = async () => {
   for await (const dirent of dir) {
     const ext = extname(dirent.name)
     if (ext === '.js' || ext === '.mjs') {
+      if (typeof AbortSignal === 'undefined' && dirent.name.startsWith('test_runner_abort')) {
+        console.log('no AbortSignal support, skipping', dirent.name)
+        continue
+      }
       const filePath = join(MESSAGE_FOLDER, dirent.name)
       const expected = filePath.replace(/\.m?js$/, '.out')
       const testFile = await fs.open(filePath)


### PR DESCRIPTION
Fixes a breaking change for Node.js v14.x that was introduced in 3.2.0. This also skips some `test/message` that rely on `AbortSignal` support. I suggest we land this and release in a semver-patch, then we revert and create a new semver-major. Thoughts?

Fixes: https://github.com/nodejs/node-core-test/issues/35